### PR TITLE
chore (PE-3511): add server http healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ RUN set -ex \
     && update-ca-certificates \
     && npm install
 
-COPY index.js ./index.js
-
+COPY *.js ./
 COPY healthcheck.sh /app/healthcheck.sh
 
 USER node

--- a/README.md
+++ b/README.md
@@ -78,17 +78,15 @@ spec:
     livenessProbe:
       exec:
         command:
-        - curl - -X POST - 'http://localhost:8080/'
+        - curl - 'http://localhost:8080/health/liveness'
       initialDelaySeconds: 30
       periodSeconds: 30
     readinessProbe:
       exec:
         command:
-        - curl - -X POST - 'http://localhost:8080/'
+        - curl - 'http://localhost:8080/health/readiness'
       initialDelaySeconds: 25
 ```
-
-Be aware that this does only check the connectivity and that the port might vary. If you want a functional check as well, you could shift to an approach like the ones used for docker with the result of the [healthcheck.sh](healthcheck.sh). But I'm not a kubernetes user, so feel free to do a pull request if you have a slim approach.
 
 ### Docker
 

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,34 @@
+const mjml2html = require('mjml');
+
+const testInput = `<mjml>
+                        <mj-body>
+                            <mj-section>
+                                <mj-column>
+                                    <mj-text font-size="16px">Test</mj-text>
+                                </mj-column>
+                            </mj-section>
+                        </mj-body>
+                    </mjml>`
+
+module.exports = {
+    create: function (app, opts) {
+
+        app.get('/health/liveness', function (req, res) {
+            return res.json({ status: 'alive' })
+        })
+
+        app.get('/health/readiness', function (req, res) {
+            try {
+                const result = mjml2html(testInput, opts)
+                if (!result) {
+                    throw Error("No rendered output")
+                }
+                return res.json({ status: 'ready' })
+            } catch (e) {
+                return res
+                    .status(500)
+                    .json({ status: 'not ready', error: JSON.stringify(e) })
+            }
+        })
+    }
+}

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const express = require('express'),
     mjml2html = require('mjml'),
     program = require('commander')
 
+const healthchecks = require('./healthcheck')
+
 program.usage('[options]').parse(process.argv)
 
 const app = express()
@@ -31,7 +33,11 @@ const charsetOpts = {
     contentType: (process.env.DEFAULT_RESPONSE_CONTENT_TYPE)
 }
 
-app.all('*', function (req, res) {
+if (opts.healthchecks) {
+    healthchecks.create(app, opts)
+}
+
+app.post('/', function (req, res) {
     // enable cors
     if (process.env.CORS) {
         res.header('Access-Control-Allow-Origin', process.env.CORS)


### PR DESCRIPTION
# Task

https://dray.atlassian.net/browse/PE-3511
https://dray.atlassian.net/browse/PT-141

# More Details

Adding an HTTP healthcheck for kubernetes to use and ensure we can render templates.

# Comments

Tried to keep the same formatting and standards the current code already uses, but this is technically a breaking change - the server was rendering on any route/method before, while now we only render POSTs on `/`. 


