### PR TITLE
chore: instrument render process on newrelic

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-require('newrelic');
+const newrelic = require('newrelic');
 
 const express = require('express'),
     bodyParser = require('body-parser'),
@@ -56,7 +56,7 @@ app.post('/', function (req, res) {
 
     try {
         const input = req.body.mjml || req.body || '';
-        const result = mjml2html(input, opts)
+        const result = newrelic.startSegment('emails/mjml/render', true, () => mjml2html(input, opts))
         const isJson = req.headers['content-type'] === 'application/json'
         return res.send(isJson ? { html: result.html } : result.html)
     } catch (ex) {


### PR DESCRIPTION
# Task

N/A

# More Details

NewRelic doesn't properly instrument our call to the mjml lib:

![image](https://user-images.githubusercontent.com/853019/231903281-60f73bef-2722-4923-b3d2-d7bbfd50080b.png)

This PR intends to fix that by manually calling [startSegment](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#startSegment).


